### PR TITLE
OpenAPI定義とUseCaseテスト拡充

### DIFF
--- a/api/src/application/use_cases/get_current_user_use_case.rs
+++ b/api/src/application/use_cases/get_current_user_use_case.rs
@@ -24,3 +24,47 @@ impl SdzGetCurrentUserUseCase {
         Ok(user)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::in_memory_user_repository::SdzInMemoryUserRepository;
+
+    fn build_user() -> SdzUser {
+        SdzUser {
+            sdz_user_id: "user-1".into(),
+            sdz_display_name: "test-user".into(),
+            sdz_email: Some("test@example.com".into()),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_current_user_success() {
+        let user = build_user();
+        let repo = Arc::new(SdzInMemoryUserRepository::new_with_seed(vec![user.clone()]));
+        let auth = SdzAuthUser {
+            sdz_user_id: user.sdz_user_id.clone(),
+        };
+        let use_case = SdzGetCurrentUserUseCase::new(repo.clone());
+
+        let result = use_case.execute(repo, auth).await.unwrap();
+
+        assert_eq!(result.sdz_user_id, user.sdz_user_id);
+        assert_eq!(result.sdz_display_name, user.sdz_display_name);
+    }
+
+    #[tokio::test]
+    async fn get_current_user_not_found() {
+        let repo = Arc::new(SdzInMemoryUserRepository::default());
+        let auth = SdzAuthUser {
+            sdz_user_id: "missing-user".into(),
+        };
+        let use_case = SdzGetCurrentUserUseCase::new(repo.clone());
+
+        let err = use_case.execute(repo, auth).await.unwrap_err();
+        match err {
+            SdzApiError::NotFound => {}
+            _ => panic!("expected not found"),
+        }
+    }
+}

--- a/api/src/application/use_cases/health_check_use_case.rs
+++ b/api/src/application/use_cases/health_check_use_case.rs
@@ -11,3 +11,15 @@ impl HealthCheckUseCase {
         HealthStatus::Healthy
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn health_check_returns_healthy() {
+        let use_case = HealthCheckUseCase::new();
+        let result = use_case.execute().await;
+        assert!(matches!(result, HealthStatus::Healthy));
+    }
+}

--- a/docs/api_architecture.md
+++ b/docs/api_architecture.md
@@ -1,5 +1,8 @@
 # spot-diggz API アーキテクチャ計画
 
+## OpenAPI 定義
+- `docs/openapi.yaml`
+
 ## STAR: API開発の目的と狙い
 ### Situation
 - Rustスクラッチ実装でCloud Run上にデプロイするマイクロサービスを構築する計画がある。

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,296 @@
+openapi: 3.0.3
+info:
+  title: spot-diggz API
+  version: "0.1.0"
+  description: |
+    spot-diggz API contract (Rust/Axum). This is an internal contract for client development.
+servers:
+  - url: http://localhost:8080
+    description: Local development
+paths:
+  /sdz/health:
+    get:
+      summary: Health check
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+  /sdz/users/me:
+    get:
+      summary: Get current user profile
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "401":
+          $ref: "#/components/responses/ErrorUnauthorized"
+        "404":
+          $ref: "#/components/responses/ErrorNotFound"
+  /sdz/spots:
+    post:
+      summary: Create a skate spot (mobile only)
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ClientHeader"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSpotInput"
+      responses:
+        "200":
+          description: Created spot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Spot"
+        "400":
+          $ref: "#/components/responses/ErrorBadRequest"
+        "401":
+          $ref: "#/components/responses/ErrorUnauthorized"
+        "403":
+          $ref: "#/components/responses/ErrorForbidden"
+        "500":
+          $ref: "#/components/responses/ErrorInternal"
+    get:
+      summary: List spots
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Spot"
+        "500":
+          $ref: "#/components/responses/ErrorInternal"
+  /sdz/spots/{spot_id}:
+    get:
+      summary: Get a spot by ID
+      parameters:
+        - name: spot_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Spot"
+        "404":
+          $ref: "#/components/responses/ErrorNotFound"
+        "500":
+          $ref: "#/components/responses/ErrorInternal"
+  /sdz/spots/upload-url:
+    post:
+      summary: Generate signed upload URL (mobile only)
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ClientHeader"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UploadUrlRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadUrlResponse"
+        "400":
+          $ref: "#/components/responses/ErrorBadRequest"
+        "401":
+          $ref: "#/components/responses/ErrorUnauthorized"
+        "403":
+          $ref: "#/components/responses/ErrorForbidden"
+        "500":
+          $ref: "#/components/responses/ErrorInternal"
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    ClientHeader:
+      name: X-SDZ-Client
+      in: header
+      required: true
+      description: Client type (`ios` or `android`) for mobile-only endpoints.
+      schema:
+        type: string
+        enum: [ios, android]
+  schemas:
+    HealthResponse:
+      type: object
+      required: [status, message]
+      properties:
+        status:
+          type: string
+          example: healthy
+        message:
+          type: string
+          example: spot-diggz api is running
+    ErrorResponse:
+      type: object
+      required: [code, errorCode, message]
+      properties:
+        code:
+          type: integer
+          format: int32
+          example: 401
+        errorCode:
+          type: string
+          example: SDZ-E-1001
+        message:
+          type: string
+          example: Unauthorized
+    SpotLocation:
+      type: object
+      required: [lat, lng]
+      properties:
+        lat:
+          type: number
+          format: double
+          example: 35.6812
+        lng:
+          type: number
+          format: double
+          example: 139.7671
+    Spot:
+      type: object
+      required:
+        - spotId
+        - name
+        - tags
+        - images
+        - userId
+        - createdAt
+        - updatedAt
+      properties:
+        spotId:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        location:
+          $ref: "#/components/schemas/SpotLocation"
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: string
+        images:
+          type: array
+          items:
+            type: string
+        userId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    CreateSpotInput:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        location:
+          $ref: "#/components/schemas/SpotLocation"
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: string
+        images:
+          type: array
+          items:
+            type: string
+    UploadUrlRequest:
+      type: object
+      required: [contentType]
+      properties:
+        contentType:
+          type: string
+          example: image/jpeg
+    UploadUrlResponse:
+      type: object
+      required: [uploadUrl, objectUrl, objectName, expiresAt]
+      properties:
+        uploadUrl:
+          type: string
+        objectUrl:
+          type: string
+        objectName:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+    User:
+      type: object
+      required: [userId, displayName]
+      properties:
+        userId:
+          type: string
+        displayName:
+          type: string
+        email:
+          type: string
+          nullable: true
+  responses:
+    ErrorBadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    ErrorUnauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    ErrorForbidden:
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    ErrorNotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    ErrorInternal:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,12 +10,8 @@ function formatCoords(location?: SdzSpot['location']) {
 }
 
 function App() {
-<<<<<<< HEAD
-  const { user, login, logout, loading: authLoading } = useAuth();
-=======
   const {
     user,
-    idToken,
     loginWithGoogle,
     loginWithEmail,
     signupWithEmail,
@@ -23,31 +19,14 @@ function App() {
     logout,
     loading: authLoading,
   } = useAuth();
->>>>>>> origin/develop
   const [spots, setSpots] = useState<SdzSpot[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
-<<<<<<< HEAD
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-=======
   const [loginEmail, setLoginEmail] = useState('');
   const [loginPassword, setLoginPassword] = useState('');
   const [signupEmail, setSignupEmail] = useState('');
   const [signupPassword, setSignupPassword] = useState('');
-  const [creating, setCreating] = useState(false);
-  const [createError, setCreateError] = useState<string | null>(null);
-  const [form, setForm] = useState({
-    name: '',
-    description: '',
-    lat: '',
-    lng: '',
-    tags: '',
-    image: null as File | null,
-  });
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
->>>>>>> origin/develop
 
   const subtitle = useMemo(
     () => `API base: ${apiUrl}（GET /sdz/spots を表示中）`,
@@ -198,9 +177,6 @@ function App() {
         )}
       </div>
 
-<<<<<<< HEAD
-      {user && (
-=======
       {/* 未認証ユーザー向けの案内（専用ビュー） */}
       {isEmailPending && (
         <div className="sdz-card" style={{ marginBottom: 16 }}>
@@ -226,7 +202,6 @@ function App() {
       {/* 認証済みユーザー専用コンテンツ */}
       {!isEmailPending && user && (
         /* 新規/更新ボタンプレースホルダ */
->>>>>>> origin/develop
         <div className="sdz-card" style={{ marginBottom: 16 }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
             <div>

--- a/ui/src/contexts/AuthProvider.tsx
+++ b/ui/src/contexts/AuthProvider.tsx
@@ -1,20 +1,13 @@
-/* eslint-disable react-refresh/only-export-components */
 import {
-  onAuthStateChanged,
   GoogleAuthProvider,
-  signInWithPopup,
   createUserWithEmailAndPassword,
-  signInWithEmailAndPassword,
+  onAuthStateChanged,
   sendEmailVerification,
+  signInWithEmailAndPassword,
+  signInWithPopup,
   signOut,
 } from 'firebase/auth';
-<<<<<<< HEAD:ui/src/contexts/AuthProvider.tsx
-import { useEffect, useMemo, useState } from 'react';
-import { auth } from '../firebase';
-import { AuthContext } from './auth-context';
-=======
-import { createContext, useContext, useEffect, useMemo, useState, useCallback } from 'react';
-import { auth } from '../firebase';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   doc,
   getDoc,
@@ -22,31 +15,8 @@ import {
   serverTimestamp,
   setDoc,
 } from 'firebase/firestore';
-
-type AuthContextValue = {
-  user: User | null;
-  idToken: string | null;
-  loading: boolean;
-  loginWithGoogle: () => Promise<void>;
-  loginWithEmail: (email: string, password: string) => Promise<void>;
-  signupWithEmail: (email: string, password: string) => Promise<void>;
-  resendVerification: () => Promise<void>;
-  logout: () => Promise<void>;
-};
-
-const AuthContext = createContext<AuthContextValue>({
-  user: null,
-  idToken: null,
-  loading: true,
-  loginWithGoogle: async () => {},
-  loginWithEmail: async () => {},
-  signupWithEmail: async () => {},
-  resendVerification: async () => {},
-  logout: async () => {},
-});
-
-export const useAuth = () => useContext(AuthContext);
->>>>>>> origin/develop:ui/src/contexts/AuthContext.tsx
+import { auth } from '../firebase';
+import { AuthContext } from './auth-context';
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState(auth.currentUser);

--- a/ui/src/contexts/auth-context.ts
+++ b/ui/src/contexts/auth-context.ts
@@ -5,7 +5,10 @@ export type AuthContextValue = {
   user: User | null;
   idToken: string | null;
   loading: boolean;
-  login: (email: string, password: string) => Promise<void>;
+  loginWithGoogle: () => Promise<void>;
+  loginWithEmail: (email: string, password: string) => Promise<void>;
+  signupWithEmail: (email: string, password: string) => Promise<void>;
+  resendVerification: () => Promise<void>;
   logout: () => Promise<void>;
 };
 
@@ -13,6 +16,9 @@ export const AuthContext = createContext<AuthContextValue>({
   user: null,
   idToken: null,
   loading: true,
-  login: async () => {},
+  loginWithGoogle: async () => {},
+  loginWithEmail: async () => {},
+  signupWithEmail: async () => {},
+  resendVerification: async () => {},
   logout: async () => {},
 });

--- a/ui/src/setupTests.ts
+++ b/ui/src/setupTests.ts
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
 import '@testing-library/jest-dom/vitest';
-=======
-import '@testing-library/jest-dom';
->>>>>>> origin/develop


### PR DESCRIPTION
## 変更概要
- OpenAPI定義を追加し、API契約を内部向けに固定
- health/userのUseCaseテストを追加（正常系・NotFound）
- UIのマージ競合マーカー除去とAuthProviderの整理
- テスト設定（setupTests）を整合

## 影響範囲
- docs/openapi.yaml
- api/src/application/use_cases/*
- ui/src/*

## 確認
- cargo fmt / clippy / test / build: PASS
- npm lint / type-check / test / build: PASS

Closes #111
Closes #115
Refs #110
