### PR TITLE
OpenAPIにclient区分を追記

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -11,6 +11,10 @@ paths:
   /sdz/health:
     get:
       summary: Health check
+      x-sdz-client:
+        - web
+        - ios
+        - android
       responses:
         "200":
           description: OK
@@ -23,6 +27,10 @@ paths:
       summary: Get current user profile
       security:
         - BearerAuth: []
+      x-sdz-client:
+        - web
+        - ios
+        - android
       responses:
         "200":
           description: OK
@@ -41,6 +49,9 @@ paths:
         - BearerAuth: []
       parameters:
         - $ref: "#/components/parameters/ClientHeader"
+      x-sdz-client:
+        - ios
+        - android
       requestBody:
         required: true
         content:
@@ -64,6 +75,10 @@ paths:
           $ref: "#/components/responses/ErrorInternal"
     get:
       summary: List spots
+      x-sdz-client:
+        - web
+        - ios
+        - android
       responses:
         "200":
           description: OK
@@ -84,6 +99,10 @@ paths:
           required: true
           schema:
             type: string
+      x-sdz-client:
+        - web
+        - ios
+        - android
       responses:
         "200":
           description: OK
@@ -102,6 +121,9 @@ paths:
         - BearerAuth: []
       parameters:
         - $ref: "#/components/parameters/ClientHeader"
+      x-sdz-client:
+        - ios
+        - android
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## 変更概要
- OpenAPI に x-sdz-client を追記して、Web/iOS/Android の利用範囲を明記

## 影響範囲
- docs/openapi.yaml
