### PR TITLE
feat(api): trustLevel/trustSources を追加

### DIFF
--- a/api/src/application/use_cases/create_spot_use_case.rs
+++ b/api/src/application/use_cases/create_spot_use_case.rs
@@ -64,7 +64,10 @@ fn map_validation_error(err: SdzSpotValidationError) -> SdzApiError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::infrastructure::in_memory_spot_repository::SdzInMemorySpotRepository;
+    use crate::{
+        domain::models::SdzSpotTrustLevel,
+        infrastructure::in_memory_spot_repository::SdzInMemorySpotRepository,
+    };
 
     fn build_input() -> CreateSpotInput {
         CreateSpotInput {
@@ -94,6 +97,11 @@ mod tests {
         assert_eq!(result.sdz_user_id, "user-1");
         assert!(!result.sdz_spot_id.is_empty());
         assert_eq!(result.tags.len(), 1);
+        assert!(matches!(
+            result.sdz_trust_level,
+            SdzSpotTrustLevel::Unverified
+        ));
+        assert!(result.sdz_trust_sources.is_empty());
         assert!(repo
             .find_by_id(&result.sdz_spot_id)
             .await

--- a/api/src/application/use_cases/list_spots_use_case.rs
+++ b/api/src/application/use_cases/list_spots_use_case.rs
@@ -25,7 +25,10 @@ impl SdzListSpotsUseCase {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::infrastructure::in_memory_spot_repository::SdzInMemorySpotRepository;
+    use crate::{
+        domain::models::SdzSpotTrustLevel,
+        infrastructure::in_memory_spot_repository::SdzInMemorySpotRepository,
+    };
     use chrono::{FixedOffset, TimeZone};
 
     #[tokio::test]
@@ -48,6 +51,8 @@ mod tests {
             location: None,
             tags: vec![],
             images: vec![],
+            sdz_trust_level: SdzSpotTrustLevel::Unverified,
+            sdz_trust_sources: vec![],
             sdz_user_id: "user".into(),
             created_at: tz.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
             updated_at: tz.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),

--- a/api/src/domain/models.rs
+++ b/api/src/domain/models.rs
@@ -43,12 +43,23 @@ pub struct SdzSpot {
     pub location: Option<SdzSpotLocation>,
     pub tags: Vec<String>,
     pub images: Vec<String>,
+    #[serde(rename = "trustLevel")]
+    pub sdz_trust_level: SdzSpotTrustLevel,
+    #[serde(rename = "trustSources")]
+    pub sdz_trust_sources: Vec<String>,
     #[serde(rename = "userId")]
     pub sdz_user_id: String,
     #[serde(rename = "createdAt")]
     pub created_at: DateTime<FixedOffset>,
     #[serde(rename = "updatedAt")]
     pub updated_at: DateTime<FixedOffset>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SdzSpotTrustLevel {
+    Verified,
+    Unverified,
 }
 
 impl SdzSpot {
@@ -69,6 +80,8 @@ impl SdzSpot {
             location,
             tags,
             images,
+            sdz_trust_level: SdzSpotTrustLevel::Unverified,
+            sdz_trust_sources: Vec::new(),
             sdz_user_id,
             created_at: now_jst(),
             updated_at: now_jst(),

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -163,10 +163,7 @@ function App() {
   const [sdzSearchText, setSdzSearchText] = useState('');
   const [sdzSelectedTag, setSdzSelectedTag] = useState('all');
 
-  const subtitle = useMemo(
-    () => `API base: ${apiUrl}（GET /sdz/spots を表示中）`,
-    [apiUrl],
-  );
+  const subtitle = `API base: ${apiUrl}（GET /sdz/spots を表示中）`;
   const isEmailPending = user && !user.emailVerified;
   const sdzAvailableTags = useMemo(() => {
     const tagSet = new Set<string>();

--- a/ui/src/types/spot.ts
+++ b/ui/src/types/spot.ts
@@ -10,6 +10,8 @@ export interface SdzSpot {
   location?: SdzSpotLocation;
   tags: string[];
   images: string[];
+  trustLevel: 'verified' | 'unverified';
+  trustSources?: string[];
   userId: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## 概要
- スポットに trustLevel / trustSources を追加し、デフォルトは unverified
- Firestore 保存/取得で trustLevel / trustSources を反映（欠損時は unverified/空配列）
- UI型とユースケーステストを更新

## 変更点
- APIモデルに trustLevel/trustSources を追加
- Firestoreの保存/復元ロジックを拡張
- UI型/テスト整備

Refs #144