### PR TITLE
feat(ui): web閲覧UXを整理

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,9 +1,25 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import App from './App';
 import { MemoryRouter } from 'react-router-dom';
 
 describe('App', () => {
+  beforeEach(() => {
+    if (!window.localStorage || typeof window.localStorage.clear !== 'function') {
+      const store = new Map<string, string>();
+      Object.defineProperty(window, 'localStorage', {
+        value: {
+          getItem: (key: string) => store.get(key) ?? null,
+          setItem: (key: string, value: string) => store.set(key, value),
+          removeItem: (key: string) => store.delete(key),
+          clear: () => store.clear(),
+        },
+        configurable: true,
+      });
+    }
+    window.localStorage.clear();
+  });
+
   it('renders list heading', () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -15,7 +31,83 @@ describe('App', () => {
       </MemoryRouter>,
     );
     return waitFor(() => {
-      expect(screen.getByText(/スポット一覧/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: /Spotを掘る。滑りに行く。旅を作る。/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('toggles favorites in list', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          spotId: 'spot-1',
+          name: 'Favorite Spot',
+          description: null,
+          location: { lat: 35.0, lng: 139.0 },
+          tags: ['smoke'],
+          images: [],
+          trustLevel: 'unverified',
+          trustSources: [],
+          userId: 'user-1',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+    } as Response);
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Favorite Spot')).toBeInTheDocument();
+    });
+
+    const addButton = screen.getByRole('button', { name: '☆' });
+    fireEvent.click(addButton);
+    expect(screen.getByRole('button', { name: '★' })).toBeInTheDocument();
+  });
+
+  it('shows favorites page', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        {
+          spotId: 'spot-1',
+          name: 'Favorite Spot',
+          description: null,
+          location: { lat: 35.0, lng: 139.0 },
+          tags: ['smoke'],
+          images: [],
+          trustLevel: 'unverified',
+          trustSources: [],
+          userId: 'user-1',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+    } as Response);
+
+    window.localStorage.setItem('sdzFavorites', JSON.stringify(['spot-1']));
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Favorite Spot')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Favorites' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'お気に入り一覧' })).toBeInTheDocument();
     });
   });
 });

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,18 +4,62 @@ import { useAuth } from './contexts/useAuth';
 import { Route, Routes, useNavigate, useParams } from 'react-router-dom';
 
 const apiUrl = import.meta.env.VITE_SDZ_API_URL || 'http://localhost:8080';
+const SDZ_FAVORITES_PAGE_SIZE = 8;
 
 function formatCoords(location?: SdzSpot['location']) {
   if (!location) return 'N/A';
   return `${location.lat.toFixed(4)}, ${location.lng.toFixed(4)}`;
 }
 
+function formatDateTime(value?: string) {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function paginate<T>(items: T[], page: number, perPage: number) {
+  const totalPages = Math.max(1, Math.ceil(items.length / perPage));
+  const safePage = Math.min(Math.max(page, 1), totalPages);
+  const start = (safePage - 1) * perPage;
+  return {
+    page: safePage,
+    totalPages,
+    items: items.slice(start, start + perPage),
+  };
+}
+
+function getInitialFavorites(): string[] {
+  if (typeof window === 'undefined') return [];
+  const raw = window.localStorage.getItem('sdzFavorites');
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((v) => typeof v === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
 type SdzSpotDetailProps = {
   spots: SdzSpot[];
   apiUrl: string;
+  favorites: string[];
+  onToggleFavorite: (spotId: string) => void;
 };
 
-function SdzSpotDetailPage({ spots, apiUrl }: SdzSpotDetailProps) {
+function SdzSpotDetailPage({
+  spots,
+  apiUrl,
+  favorites,
+  onToggleFavorite,
+}: SdzSpotDetailProps) {
   const { spotId } = useParams();
   const navigate = useNavigate();
   const [sdzDetail, setSdzDetail] = useState<SdzSpot | null>(null);
@@ -57,9 +101,19 @@ function SdzSpotDetailPage({ spots, apiUrl }: SdzSpotDetailProps) {
     };
   }, [apiUrl, spotId, spots]);
 
+  const sdzRelatedSpots = useMemo(() => {
+    if (!sdzDetail) return [];
+    const baseTags = new Set(sdzDetail.tags ?? []);
+    const related = spots.filter((spot) => {
+      if (spot.spotId === sdzDetail.spotId) return false;
+      return spot.tags?.some((tag) => baseTags.has(tag));
+    });
+    return related.slice(0, 5);
+  }, [sdzDetail, spots]);
+
   if (!spotId) {
     return (
-      <div className="sdz-card">
+      <div className="sdz-card sdz-empty">
         <p>スポットIDが指定されていません。</p>
         <button type="button" onClick={() => navigate('/')}>
           一覧へ戻る
@@ -87,7 +141,7 @@ function SdzSpotDetailPage({ spots, apiUrl }: SdzSpotDetailProps) {
 
   if (!sdzDetail) {
     return (
-      <div className="sdz-card">
+      <div className="sdz-card sdz-empty">
         <p>該当するスポットが見つかりませんでした。</p>
         <button type="button" onClick={() => navigate('/')}>
           一覧へ戻る
@@ -97,47 +151,82 @@ function SdzSpotDetailPage({ spots, apiUrl }: SdzSpotDetailProps) {
   }
 
   return (
-    <div className="sdz-card sdz-detail">
-      <div className="sdz-detail-header">
-        <div>
-          <h2>{sdzDetail.name}</h2>
-          <div className="sdz-meta">
-            投稿者: {sdzDetail.userId} / 位置: {formatCoords(sdzDetail.location)}
-            / 作成: {sdzDetail.createdAt}
+    <div className="sdz-detail-layout">
+      <div className="sdz-card sdz-detail">
+        <div className="sdz-detail-header">
+          <div>
+            <p className="sdz-eyebrow">Spot Detail</p>
+            <h2>{sdzDetail.name}</h2>
+            <div className="sdz-meta">
+              投稿者: {sdzDetail.userId} / 位置: {formatCoords(sdzDetail.location)} / 作成:
+              {formatDateTime(sdzDetail.createdAt)}
+            </div>
+          </div>
+          <div className="sdz-detail-actions">
+            <button
+              type="button"
+              className={`sdz-favorite ${favorites.includes(sdzDetail.spotId) ? 'is-active' : ''}`}
+              onClick={() => onToggleFavorite(sdzDetail.spotId)}
+            >
+              {favorites.includes(sdzDetail.spotId) ? '★ 保存済み' : '☆ お気に入り'}
+            </button>
+            <button type="button" className="sdz-ghost" onClick={() => navigate('/')}>
+              一覧へ戻る
+            </button>
           </div>
         </div>
-        <button type="button" onClick={() => navigate('/')}>
-          一覧へ戻る
-        </button>
-      </div>
-      {sdzDetail.description && <p>{sdzDetail.description}</p>}
-      {sdzDetail.tags && sdzDetail.tags.length > 0 && (
-        <div className="sdz-tags">
-          {sdzDetail.tags.map((tag) => (
-            <span key={tag} className="sdz-tag">
-              {tag}
-            </span>
-          ))}
-        </div>
-      )}
-      <div>
-        <strong>写真</strong>
-        {sdzDetail.images?.length ? (
-          <div className="sdz-image-grid">
-            {sdzDetail.images.map((imageUrl) => (
-              <img
-                key={imageUrl}
-                src={imageUrl}
-                alt={`${sdzDetail.name}の画像`}
-                className="sdz-image"
-                loading="lazy"
-              />
+        {sdzDetail.description && <p>{sdzDetail.description}</p>}
+        {sdzDetail.tags && sdzDetail.tags.length > 0 && (
+          <div className="sdz-tags">
+            {sdzDetail.tags.map((tag) => (
+              <span key={tag} className="sdz-tag">
+                {tag}
+              </span>
             ))}
           </div>
-        ) : (
-          <p className="sdz-meta">画像はまだ登録されていません。</p>
         )}
+        <div>
+          <strong>写真</strong>
+          {sdzDetail.images?.length ? (
+            <div className="sdz-image-grid">
+              {sdzDetail.images.map((imageUrl) => (
+                <img
+                  key={imageUrl}
+                  src={imageUrl}
+                  alt={`${sdzDetail.name}の画像`}
+                  className="sdz-image"
+                  loading="lazy"
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="sdz-meta">画像はまだ登録されていません。</p>
+          )}
+        </div>
       </div>
+      <aside className="sdz-related">
+        <div className="sdz-card">
+          <h3>関連スポット</h3>
+          <p className="sdz-meta">同じタグのスポットを優先表示</p>
+          {sdzRelatedSpots.length === 0 ? (
+            <p className="sdz-meta">まだ関連スポットがありません。</p>
+          ) : (
+            <div className="sdz-related-list">
+              {sdzRelatedSpots.map((spot) => (
+                <button
+                  key={spot.spotId}
+                  type="button"
+                  className="sdz-related-item"
+                  onClick={() => navigate(`/spots/${spot.spotId}`)}
+                >
+                  <span>{spot.name}</span>
+                  <span className="sdz-meta">{formatCoords(spot.location)}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </aside>
     </div>
   );
 }
@@ -151,6 +240,7 @@ function App() {
     resendVerification,
     logout,
     loading: authLoading,
+    sendPasswordReset,
   } = useAuth();
   const [spots, setSpots] = useState<SdzSpot[]>([]);
   const [loading, setLoading] = useState(true);
@@ -158,15 +248,14 @@ function App() {
   const [authError, setAuthError] = useState<string | null>(null);
   const [loginEmail, setLoginEmail] = useState('');
   const [loginPassword, setLoginPassword] = useState('');
-  const [signupEmail, setSignupEmail] = useState('');
-  const [signupPassword, setSignupPassword] = useState('');
+  const [sdzAuthMode, setSdzAuthMode] = useState<'login' | 'signup'>('login');
   const [sdzSearchText, setSdzSearchText] = useState('');
   const [sdzSelectedTag, setSdzSelectedTag] = useState('all');
+  const [sdzFavorites, setSdzFavorites] = useState<string[]>(getInitialFavorites);
+  const [sdzProfileMessage, setSdzProfileMessage] = useState<string | null>(null);
+  const [sdzFavoritesPage, setSdzFavoritesPage] = useState(1);
 
-  const subtitle = useMemo(
-    () => `API base: ${apiUrl}（GET /sdz/spots を表示中）`,
-    [apiUrl],
-  );
+  const subtitle = `API base: ${apiUrl}（GET /sdz/spots を表示中）`;
   const isEmailPending = user && !user.emailVerified;
   const sdzAvailableTags = useMemo(() => {
     const tagSet = new Set<string>();
@@ -215,6 +304,15 @@ function App() {
     return () => controller.abort();
   }, []);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('sdzFavorites', JSON.stringify(sdzFavorites));
+  }, [sdzFavorites]);
+
+  useEffect(() => {
+    setSdzFavoritesPage(1);
+  }, [sdzFavorites.length]);
+
   const handleLoginWithGoogle = async () => {
     setAuthError(null);
     try {
@@ -240,10 +338,20 @@ function App() {
     e.preventDefault();
     setAuthError(null);
     try {
-      await signupWithEmail(signupEmail, signupPassword);
-      setSignupEmail('');
-      setSignupPassword('');
+      await signupWithEmail(loginEmail, loginPassword);
+      setLoginEmail('');
+      setLoginPassword('');
     } catch (err) {
+      if (
+        err &&
+        typeof err === 'object' &&
+        'code' in err &&
+        (err as { code?: string }).code === 'auth/email-already-in-use'
+      ) {
+        setAuthError('すでに登録済みです。ログインしてください。');
+        setSdzAuthMode('login');
+        return;
+      }
       setAuthError((err as Error).message);
     }
   };
@@ -263,26 +371,85 @@ function App() {
     await logout();
   };
 
+  const handleAuthSubmit = async (e: React.FormEvent) => {
+    if (sdzAuthMode === 'login') {
+      await handleLoginWithEmail(e);
+      return;
+    }
+    await handleSignupWithEmail(e);
+  };
+
+  const handleToggleFavorite = (spotId: string) => {
+    setSdzFavorites((prev) =>
+      prev.includes(spotId)
+        ? prev.filter((id) => id !== spotId)
+        : [...prev, spotId],
+    );
+  };
+
+  const handlePasswordReset = async () => {
+    setSdzProfileMessage(null);
+    try {
+      await sendPasswordReset();
+      setSdzProfileMessage('パスワード再設定メールを送信しました。');
+    } catch (err) {
+      setSdzProfileMessage((err as Error).message);
+    }
+  };
+
   const handleRefresh = () => fetchSpots();
   const handleResetFilters = () => {
     setSdzSearchText('');
     setSdzSelectedTag('all');
   };
   const navigate = useNavigate();
+  const sdzMySpots = useMemo(
+    () => spots.filter((spot) => (user ? spot.userId === user.uid : false)),
+    [spots, user],
+  );
+  const sdzFavoriteSpots = useMemo(
+    () => spots.filter((spot) => sdzFavorites.includes(spot.spotId)),
+    [sdzFavorites, spots],
+  );
+  const sdzFavoritesPaging = useMemo(
+    () => paginate(sdzFavoriteSpots, sdzFavoritesPage, SDZ_FAVORITES_PAGE_SIZE),
+    [sdzFavoriteSpots, sdzFavoritesPage],
+  );
+  const sdzHasPasswordProvider = useMemo(
+    () => user?.providerData?.some((provider) => provider.providerId === 'password') ?? false,
+    [user],
+  );
 
   return (
     <div className="sdz-container">
-      <div className="sdz-header">
-        <h1>spot-diggz スポット一覧</h1>
-        <span className="sdz-meta">{subtitle}</span>
-      </div>
+      <header className="sdz-nav">
+        <div className="sdz-brand">
+          <span className="sdz-brand-mark">sdz</span>
+          <span>spot-diggz</span>
+        </div>
+        <nav className="sdz-nav-links">
+          <button type="button" className="sdz-ghost" onClick={() => navigate('/')}>
+            Spots
+          </button>
+          <button
+            type="button"
+            className="sdz-ghost"
+            onClick={() => navigate('/favorites')}
+          >
+            Favorites
+          </button>
+          <button type="button" className="sdz-ghost" onClick={() => navigate('/me')}>
+            My Page
+          </button>
+        </nav>
+      </header>
 
       {/* 認証セクション */}
-      <div className="sdz-card" style={{ marginBottom: 16 }}>
+      <div className="sdz-card sdz-auth-card">
         {authLoading ? (
           <p>認証状態を確認中...</p>
         ) : user ? (
-          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+          <div className="sdz-auth-info">
             <div>
               <strong>ログイン中:</strong> {user.email ?? user.uid}
               <div className="sdz-meta">uid: {user.uid}</div>
@@ -290,17 +457,34 @@ function App() {
             <button onClick={handleLogout}>ログアウト</button>
           </div>
         ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <div className="sdz-auth-actions">
+            <div className="sdz-auth-row">
               <button type="button" onClick={handleLoginWithGoogle} disabled={authLoading}>
                 Googleでログイン / 新規登録
               </button>
             </div>
 
-            <form onSubmit={handleLoginWithEmail} style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <div className="sdz-auth-row">
+              <button
+                type="button"
+                className={`sdz-ghost ${sdzAuthMode === 'login' ? 'is-active' : ''}`}
+                onClick={() => setSdzAuthMode('login')}
+              >
+                メールでログイン
+              </button>
+              <button
+                type="button"
+                className={`sdz-ghost ${sdzAuthMode === 'signup' ? 'is-active' : ''}`}
+                onClick={() => setSdzAuthMode('signup')}
+              >
+                メールで新規登録
+              </button>
+            </div>
+
+            <form onSubmit={handleAuthSubmit} className="sdz-auth-row">
               <input
                 type="email"
-                placeholder="メールアドレスでログイン"
+                placeholder="メールアドレス"
                 value={loginEmail}
                 onChange={(e) => setLoginEmail(e.target.value)}
                 required
@@ -313,27 +497,7 @@ function App() {
                 required
               />
               <button type="submit" disabled={authLoading}>
-                メールでログイン
-              </button>
-            </form>
-
-            <form onSubmit={handleSignupWithEmail} style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-              <input
-                type="email"
-                placeholder="メールアドレス（新規登録）"
-                value={signupEmail}
-                onChange={(e) => setSignupEmail(e.target.value)}
-                required
-              />
-              <input
-                type="password"
-                placeholder="パスワード（新規登録）"
-                value={signupPassword}
-                onChange={(e) => setSignupPassword(e.target.value)}
-                required
-              />
-              <button type="submit" disabled={authLoading}>
-                メールで新規登録
+                {sdzAuthMode === 'login' ? 'ログイン' : '新規登録'}
               </button>
             </form>
             {authError && <div className="sdz-error">Authエラー: {authError}</div>}
@@ -366,8 +530,8 @@ function App() {
       {/* 認証済みユーザー専用コンテンツ */}
       {!isEmailPending && user && (
         /* 新規/更新ボタンプレースホルダ */
-        <div className="sdz-card" style={{ marginBottom: 16 }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12 }}>
+        <div className="sdz-card sdz-mode-card">
+          <div className="sdz-mode-content">
             <div>
               <strong>閲覧専用モード</strong>
               <div className="sdz-meta">
@@ -389,27 +553,29 @@ function App() {
           path="/"
           element={
             <>
-              {!loading && !error && spots.length === 0 && (
-                <p>スポットがまだありません。</p>
-              )}
-
-              {!loading && !error && spots.length > 0 && (
-                <div className="sdz-card sdz-controls">
-                  <div className="sdz-controls-row">
-                    <div className="sdz-controls-col">
-                      <label htmlFor="sdz-search">キーワード</label>
+              <section className="sdz-hero">
+                <div className="sdz-hero-copy">
+                  <p className="sdz-eyebrow">Skate Spot Finder</p>
+                  <h1>Spotを掘る。滑りに行く。旅を作る。</h1>
+                  <p className="sdz-hero-lead">
+                    spot-diggzは、スケートスポットを探し、保存し、次のライドプランに組み込むための
+                    シンプルなディレクトリです。モバイルアプリで投稿、Webは閲覧と整理に集中します。
+                  </p>
+                  <div className="sdz-hero-actions">
+                    <div className="sdz-search">
+                      <label htmlFor="sdz-search-hero">キーワードで探す</label>
                       <input
-                        id="sdz-search"
+                        id="sdz-search-hero"
                         type="text"
                         placeholder="スポット名・タグ・説明文で検索"
                         value={sdzSearchText}
                         onChange={(e) => setSdzSearchText(e.target.value)}
                       />
                     </div>
-                    <div className="sdz-controls-col">
-                      <label htmlFor="sdz-tag">タグ</label>
+                    <div className="sdz-search">
+                      <label htmlFor="sdz-tag-hero">タグで絞る</label>
                       <select
-                        id="sdz-tag"
+                        id="sdz-tag-hero"
                         value={sdzSelectedTag}
                         onChange={(e) => setSdzSelectedTag(e.target.value)}
                       >
@@ -421,16 +587,65 @@ function App() {
                         ))}
                       </select>
                     </div>
-                    <div className="sdz-controls-col sdz-controls-meta">
+                    <div className="sdz-search-meta">
                       <span>
-                        表示中: {sdzFilteredSpots.length} / {spots.length}
+                        表示中 {sdzFilteredSpots.length} / {spots.length}
                       </span>
                       <button type="button" onClick={handleResetFilters}>
                         クリア
                       </button>
                     </div>
                   </div>
+                  <div className="sdz-hero-stats">
+                    <div>
+                      <strong>{spots.length}</strong>
+                      <span>登録スポット</span>
+                    </div>
+                    <div>
+                      <strong>{sdzFavoriteSpots.length}</strong>
+                      <span>お気に入り</span>
+                    </div>
+                    <div>
+                      <strong>{sdzAvailableTags.length}</strong>
+                      <span>タグ</span>
+                    </div>
+                  </div>
+                  <div className="sdz-hero-footnote">{subtitle}</div>
                 </div>
+                <div className="sdz-hero-panel">
+                  <div className="sdz-map-card">
+                    <div className="sdz-map-preview">
+                      <div className="sdz-map-dot" />
+                      <div className="sdz-map-dot sdz-map-dot-alt" />
+                      <div className="sdz-map-dot sdz-map-dot-alt2" />
+                    </div>
+                    <div>
+                      <h3>近くのスポットを探す</h3>
+                      <p className="sdz-meta">
+                        現在地はブラウザの位置情報設定から許可してください。モバイル環境の方が取得しやすいです。
+                      </p>
+                    </div>
+                  </div>
+                  <div className="sdz-card sdz-app-box">
+                    <h3>アプリでスポット登録</h3>
+                    <p className="sdz-meta">
+                      Webは閲覧と整理専用です。スポット登録や画像投稿はモバイルアプリから行います。
+                    </p>
+                    <div className="sdz-app-links">
+                      <button type="button" className="sdz-ghost" disabled>
+                        iOSアプリ（準備中）
+                      </button>
+                      <button type="button" className="sdz-ghost" disabled>
+                        Androidアプリ（準備中）
+                      </button>
+                    </div>
+                    <div className="sdz-meta">QR/リンクは後日追加予定</div>
+                  </div>
+                </div>
+              </section>
+
+              {!loading && !error && spots.length === 0 && (
+                <p>スポットがまだありません。</p>
               )}
 
               {!loading &&
@@ -440,39 +655,194 @@ function App() {
                   <p>条件に一致するスポットがありません。</p>
                 )}
 
-              {sdzFilteredSpots.map((spot) => (
-                <div key={spot.spotId} className="sdz-card">
-                  <div className="sdz-card-header">
-                    <h3>{spot.name}</h3>
-                    <button
-                      type="button"
-                      onClick={() => navigate(`/spots/${spot.spotId}`)}
-                    >
-                      詳細を見る
-                    </button>
-                  </div>
-                  <div className="sdz-meta">
-                    投稿者: {spot.userId} / 位置: {formatCoords(spot.location)} /
-                    作成: {spot.createdAt}
-                  </div>
-                  {spot.description && <p>{spot.description}</p>}
-                  {spot.tags && spot.tags.length > 0 && (
-                    <div className="sdz-tags">
-                      {spot.tags.map((tag) => (
-                        <span key={tag} className="sdz-tag">
-                          {tag}
-                        </span>
-                      ))}
+              <div className="sdz-spot-grid">
+                {sdzFilteredSpots.map((spot) => (
+                  <div key={spot.spotId} className="sdz-card sdz-spot-card">
+                    <div className="sdz-card-header">
+                      <div>
+                        <h3>{spot.name}</h3>
+                        <div className="sdz-meta">
+                          投稿者: {spot.userId} / 位置: {formatCoords(spot.location)} / 作成:
+                          {formatDateTime(spot.createdAt)}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        className={`sdz-favorite ${
+                          sdzFavorites.includes(spot.spotId) ? 'is-active' : ''
+                        }`}
+                        onClick={() => handleToggleFavorite(spot.spotId)}
+                      >
+                        {sdzFavorites.includes(spot.spotId) ? '★' : '☆'}
+                      </button>
                     </div>
-                  )}
-                </div>
-              ))}
+                    {spot.description && <p>{spot.description}</p>}
+                    {spot.tags && spot.tags.length > 0 && (
+                      <div className="sdz-tags">
+                        {spot.tags.map((tag) => (
+                          <span key={tag} className="sdz-tag">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    <div className="sdz-card-footer">
+                      <button type="button" onClick={() => navigate(`/spots/${spot.spotId}`)}>
+                        詳細を見る
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
             </>
           }
         />
         <Route
           path="/spots/:spotId"
-          element={<SdzSpotDetailPage spots={spots} apiUrl={apiUrl} />}
+          element={
+            <SdzSpotDetailPage
+              spots={spots}
+              apiUrl={apiUrl}
+              favorites={sdzFavorites}
+              onToggleFavorite={handleToggleFavorite}
+            />
+          }
+        />
+        <Route
+          path="/favorites"
+          element={
+            <div className="sdz-card">
+              <h2>お気に入り一覧</h2>
+              <p className="sdz-meta">ローカル保存のお気に入りスポットです。</p>
+              {sdzFavoriteSpots.length === 0 ? (
+                <p className="sdz-meta">お気に入りがありません。</p>
+              ) : (
+                <>
+                  <div className="sdz-related-list">
+                    {sdzFavoritesPaging.items.map((spot) => (
+                      <button
+                        key={spot.spotId}
+                        type="button"
+                        className="sdz-related-item"
+                        onClick={() => navigate(`/spots/${spot.spotId}`)}
+                      >
+                        <span>{spot.name}</span>
+                        <span className="sdz-meta">{formatCoords(spot.location)}</span>
+                      </button>
+                    ))}
+                  </div>
+                  <div className="sdz-pagination">
+                    <button
+                      type="button"
+                      className="sdz-ghost"
+                      onClick={() => setSdzFavoritesPage((prev) => Math.max(1, prev - 1))}
+                      disabled={sdzFavoritesPaging.page === 1}
+                    >
+                      前へ
+                    </button>
+                    <span>
+                      {sdzFavoritesPaging.page} / {sdzFavoritesPaging.totalPages}
+                    </span>
+                    <button
+                      type="button"
+                      className="sdz-ghost"
+                      onClick={() =>
+                        setSdzFavoritesPage((prev) =>
+                          Math.min(sdzFavoritesPaging.totalPages, prev + 1),
+                        )
+                      }
+                      disabled={sdzFavoritesPaging.page === sdzFavoritesPaging.totalPages}
+                    >
+                      次へ
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          }
+        />
+        <Route
+          path="/me"
+          element={
+            <div className="sdz-profile-grid">
+              <div className="sdz-card">
+                <h2>マイページ</h2>
+                <p className="sdz-meta">ログインしたユーザーの情報と保存内容</p>
+                {!user ? (
+                  <p>ログインするとマイページを利用できます。</p>
+                ) : (
+                  <>
+                    <div className="sdz-profile-summary">
+                      <div>
+                        <strong>{user.displayName || 'ユーザー名未設定'}</strong>
+                        <div className="sdz-meta">{user.email ?? user.uid}</div>
+                      </div>
+                      <div className="sdz-profile-pill">
+                        投稿 {sdzMySpots.length}件 / お気に入り {sdzFavoriteSpots.length}件
+                      </div>
+                    </div>
+                    {sdzHasPasswordProvider ? (
+                      <button type="button" className="sdz-ghost" onClick={handlePasswordReset}>
+                        パスワード再設定メールを送信
+                      </button>
+                    ) : (
+                      <div className="sdz-meta">
+                        Googleログインの場合はGoogleアカウント側でパスワードを変更してください。
+                      </div>
+                    )}
+                    {sdzProfileMessage && <p className="sdz-meta">{sdzProfileMessage}</p>}
+                    <button
+                      type="button"
+                      className="sdz-ghost"
+                      onClick={() => navigate('/favorites')}
+                    >
+                      お気に入りページへ
+                    </button>
+                  </>
+                )}
+              </div>
+              <div className="sdz-card">
+                <h3>お気に入り</h3>
+                {sdzFavoriteSpots.length === 0 ? (
+                  <p className="sdz-meta">お気に入りがありません。</p>
+                ) : (
+                  <div className="sdz-related-list">
+                    {sdzFavoriteSpots.map((spot) => (
+                      <button
+                        key={spot.spotId}
+                        type="button"
+                        className="sdz-related-item"
+                        onClick={() => navigate(`/spots/${spot.spotId}`)}
+                      >
+                        <span>{spot.name}</span>
+                        <span className="sdz-meta">{formatCoords(spot.location)}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="sdz-card">
+                <h3>自分のスポット</h3>
+                {sdzMySpots.length === 0 ? (
+                  <p className="sdz-meta">まだ投稿したスポットがありません。</p>
+                ) : (
+                  <div className="sdz-related-list">
+                    {sdzMySpots.map((spot) => (
+                      <button
+                        key={spot.spotId}
+                        type="button"
+                        className="sdz-related-item"
+                        onClick={() => navigate(`/spots/${spot.spotId}`)}
+                      >
+                        <span>{spot.name}</span>
+                        <span className="sdz-meta">{formatCoords(spot.location)}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          }
         />
       </Routes>
     </div>

--- a/ui/src/contexts/AuthProvider.tsx
+++ b/ui/src/contexts/AuthProvider.tsx
@@ -3,6 +3,7 @@ import {
   createUserWithEmailAndPassword,
   onAuthStateChanged,
   sendEmailVerification,
+  sendPasswordResetEmail,
   signInWithEmailAndPassword,
   signInWithPopup,
   signOut,
@@ -129,6 +130,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, []);
 
+  const sendPasswordReset = useCallback(async () => {
+    if (!auth.currentUser?.email) {
+      throw new Error('再設定用のメールアドレスが見つかりません。');
+    }
+    await sendPasswordResetEmail(auth, auth.currentUser.email);
+  }, []);
+
   const value = useMemo(
     () => ({
       user,
@@ -138,9 +146,20 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       loginWithEmail,
       signupWithEmail,
       resendVerification,
+      sendPasswordReset,
       logout,
     }),
-    [user, idToken, loading, loginWithGoogle, loginWithEmail, signupWithEmail, resendVerification, logout],
+    [
+      user,
+      idToken,
+      loading,
+      loginWithGoogle,
+      loginWithEmail,
+      signupWithEmail,
+      resendVerification,
+      sendPasswordReset,
+      logout,
+    ],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/ui/src/contexts/auth-context.ts
+++ b/ui/src/contexts/auth-context.ts
@@ -9,6 +9,7 @@ export type AuthContextValue = {
   loginWithEmail: (email: string, password: string) => Promise<void>;
   signupWithEmail: (email: string, password: string) => Promise<void>;
   resendVerification: () => Promise<void>;
+  sendPasswordReset: () => Promise<void>;
   logout: () => Promise<void>;
 };
 
@@ -20,5 +21,6 @@ export const AuthContext = createContext<AuthContextValue>({
   loginWithEmail: async () => {},
   signupWithEmail: async () => {},
   resendVerification: async () => {},
+  sendPasswordReset: async () => {},
   logout: async () => {},
 });

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,4 +1,26 @@
-html, body {
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Space+Grotesk:wght@400;600;700&display=swap');
+
+:root {
+  --sdz-bg: #f6f0e4;
+  --sdz-bg-soft: #fdf8f0;
+  --sdz-ink: #0e1b1f;
+  --sdz-muted: #5d6a73;
+  --sdz-accent: #ff6b35;
+  --sdz-accent-dark: #c94e1d;
+  --sdz-surface: #ffffff;
+  --sdz-surface-alt: #f1f3f2;
+  --sdz-border: #e1d9cc;
+  --sdz-shadow: 0 24px 60px rgba(15, 18, 22, 0.12);
+  --sdz-font-head: 'Space Grotesk', 'Noto Sans JP', sans-serif;
+  --sdz-font-body: 'Noto Sans JP', 'Space Grotesk', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
   margin: 0;
   padding: 0;
 }
@@ -8,48 +30,267 @@ html, body {
 }
 
 body {
-  font-family: 'Helvetica Neue', Arial, sans-serif;
-  background: #f5f7fb;
-  color: #1f2933;
+  font-family: var(--sdz-font-body);
+  color: var(--sdz-ink);
+  background:
+    radial-gradient(circle at 10% 20%, rgba(255, 200, 140, 0.2), transparent 40%),
+    radial-gradient(circle at 90% 10%, rgba(33, 158, 188, 0.2), transparent 45%),
+    linear-gradient(120deg, #f9f3e9 0%, #f4f2ec 40%, #f3f7f4 100%);
+  min-height: 100vh;
+}
+
+button,
+input,
+select {
+  font-family: inherit;
+}
+
+button {
+  background: var(--sdz-accent);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 10px 20px rgba(255, 107, 53, 0.28);
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.sdz-ghost {
+  background: transparent;
+  border: 1px solid var(--sdz-border);
+  color: var(--sdz-ink);
+  box-shadow: none;
+}
+
+.sdz-ghost.is-active {
+  border-color: var(--sdz-accent);
+  color: var(--sdz-accent);
 }
 
 .sdz-container {
-  max-width: 960px;
+  max-width: 1180px;
   margin: 0 auto;
-  padding: 32px 20px 48px;
+  padding: 24px 20px 64px;
 }
 
-.sdz-header {
+.sdz-nav {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 20px;
+  margin-bottom: 24px;
 }
 
-.sdz-card {
-  background: #fff;
-  border: 1px solid #e5e8ed;
-  border-radius: 10px;
-  padding: 16px;
-  margin-bottom: 12px;
-  box-shadow: 0 4px 10px rgba(17, 24, 39, 0.04);
-}
-
-.sdz-card h3 {
-  margin: 0 0 8px;
-  font-size: 18px;
-}
-
-.sdz-card h2 {
-  margin: 0 0 8px;
+.sdz-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--sdz-font-head);
+  font-weight: 700;
   font-size: 20px;
 }
 
+.sdz-brand-mark {
+  background: var(--sdz-ink);
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.sdz-nav-links {
+  display: flex;
+  gap: 12px;
+}
+
+.sdz-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 24px;
+  margin-bottom: 28px;
+}
+
+.sdz-hero-copy h1 {
+  font-family: var(--sdz-font-head);
+  font-size: clamp(32px, 4vw, 48px);
+  line-height: 1.05;
+  margin: 8px 0 16px;
+}
+
+.sdz-hero-lead {
+  color: var(--sdz-muted);
+  font-size: 16px;
+  line-height: 1.6;
+  margin-bottom: 18px;
+}
+
+.sdz-hero-actions {
+  display: grid;
+  gap: 12px;
+  background: var(--sdz-surface);
+  border-radius: 18px;
+  padding: 16px;
+  border: 1px solid var(--sdz-border);
+  box-shadow: var(--sdz-shadow);
+}
+
+.sdz-search {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sdz-search label {
+  font-size: 12px;
+  color: var(--sdz-muted);
+}
+
+.sdz-search input,
+.sdz-search select {
+  border-radius: 12px;
+  border: 1px solid var(--sdz-border);
+  padding: 10px 12px;
+  font-size: 14px;
+  background: #fff;
+}
+
+.sdz-search-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  color: var(--sdz-muted);
+}
+
+.sdz-hero-stats {
+  display: flex;
+  gap: 18px;
+  margin-top: 16px;
+}
+
+.sdz-hero-stats div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--sdz-muted);
+}
+
+.sdz-hero-stats strong {
+  font-size: 18px;
+  color: var(--sdz-ink);
+}
+
+.sdz-hero-footnote {
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--sdz-muted);
+}
+
+.sdz-hero-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sdz-map-card {
+  background: var(--sdz-ink);
+  color: #fff;
+  border-radius: 20px;
+  padding: 16px;
+  box-shadow: var(--sdz-shadow);
+  display: grid;
+  gap: 12px;
+}
+
+.sdz-map-preview {
+  position: relative;
+  background: linear-gradient(120deg, #0f2b2f, #183e3d 60%, #0f2b2f);
+  border-radius: 16px;
+  height: 140px;
+  overflow: hidden;
+}
+
+.sdz-map-dot {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--sdz-accent);
+  top: 30%;
+  left: 18%;
+  animation: sdz-float 4s ease-in-out infinite;
+}
+
+.sdz-map-dot-alt {
+  width: 12px;
+  height: 12px;
+  top: 65%;
+  left: 55%;
+  background: #f4b43f;
+  animation-delay: -1.4s;
+}
+
+.sdz-map-dot-alt2 {
+  width: 10px;
+  height: 10px;
+  top: 20%;
+  left: 70%;
+  background: #8be0c6;
+  animation-delay: -2.4s;
+}
+
+.sdz-app-box h3 {
+  margin: 0 0 6px;
+}
+
+.sdz-app-links {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.sdz-card {
+  background: var(--sdz-surface);
+  border: 1px solid var(--sdz-border);
+  border-radius: 18px;
+  padding: 16px;
+  margin-bottom: 16px;
+  box-shadow: var(--sdz-shadow);
+}
+
+.sdz-card h2,
+.sdz-card h3 {
+  font-family: var(--sdz-font-head);
+  margin: 0 0 8px;
+}
+
 .sdz-meta {
-  color: #607080;
-  font-size: 13px;
+  color: var(--sdz-muted);
+  font-size: 12px;
   margin-bottom: 8px;
+}
+
+.sdz-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 11px;
+  color: var(--sdz-muted);
+  margin: 0;
 }
 
 .sdz-tags {
@@ -60,8 +301,8 @@ body {
 }
 
 .sdz-tag {
-  background: #e8f0ff;
-  color: #2856a7;
+  background: var(--sdz-surface-alt);
+  color: var(--sdz-ink);
   border-radius: 999px;
   padding: 4px 10px;
   font-size: 12px;
@@ -74,42 +315,155 @@ body {
   gap: 12px;
 }
 
-.sdz-controls {
-  margin-top: 16px;
+.sdz-card-footer {
+  margin-top: 12px;
+  display: flex;
+  justify-content: flex-end;
 }
 
-.sdz-controls-row {
+.sdz-auth-card {
+  background: var(--sdz-bg-soft);
+}
+
+.sdz-auth-info {
   display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sdz-auth-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sdz-auth-row {
+  display: flex;
+  gap: 8px;
   flex-wrap: wrap;
+}
+
+.sdz-auth-row input {
+  flex: 1;
+  min-width: 180px;
+  padding: 10px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--sdz-border);
+}
+
+.sdz-mode-card {
+  background: #fef6e8;
+}
+
+.sdz-mode-content {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sdz-spot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 16px;
 }
 
-.sdz-controls-col {
+.sdz-spot-card {
+  background: #fff;
+}
+
+.sdz-favorite {
+  background: #fff;
+  color: var(--sdz-ink);
+  border: 1px solid var(--sdz-border);
+  box-shadow: none;
+  padding: 6px 12px;
+  min-width: 48px;
+}
+
+.sdz-favorite.is-active {
+  background: var(--sdz-accent);
+  color: #fff;
+  border-color: var(--sdz-accent);
+}
+
+.sdz-detail-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 300px);
+  gap: 20px;
+}
+
+.sdz-detail-actions {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  min-width: 220px;
-  flex: 1;
-}
-
-.sdz-controls-col label {
-  font-size: 12px;
-  color: #607080;
-}
-
-.sdz-controls-col input,
-.sdz-controls-col select {
-  border: 1px solid #d6dbe3;
-  border-radius: 8px;
-  padding: 8px 10px;
-  font-size: 14px;
-}
-
-.sdz-controls-meta {
-  justify-content: flex-end;
+  gap: 8px;
   align-items: flex-end;
-  color: #607080;
-  font-size: 13px;
+}
+
+.sdz-related-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sdz-pagination {
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-end;
+  font-size: 12px;
+  color: var(--sdz-muted);
+}
+
+.sdz-related-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 10px 12px;
+  background: var(--sdz-surface-alt);
+  border: 1px solid transparent;
+  border-radius: 12px;
+  text-align: left;
+  box-shadow: none;
+  color: var(--sdz-ink);
+}
+
+.sdz-related-item:hover {
+  border-color: var(--sdz-accent);
+}
+
+.sdz-profile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.sdz-profile-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.sdz-profile-pill {
+  background: var(--sdz-surface-alt);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+}
+
+.sdz-profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.sdz-profile-form input {
+  border: 1px solid var(--sdz-border);
+  border-radius: 12px;
+  padding: 10px 12px;
 }
 
 .sdz-detail {
@@ -136,37 +490,49 @@ body {
   width: 100%;
   height: 160px;
   object-fit: cover;
-  border-radius: 8px;
-  border: 1px solid #e5e8ed;
+  border-radius: 12px;
+  border: 1px solid var(--sdz-border);
 }
 
 .sdz-error {
-  color: #b91c1c;
-  background: #fee2e2;
-  border: 1px solid #fecaca;
+  color: #b42318;
+  background: #fee4df;
+  border: 1px solid #f8c3b4;
   padding: 10px;
-  border-radius: 8px;
+  border-radius: 12px;
   margin-bottom: 12px;
 }
 
-.sdz-form-row {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
+.sdz-empty {
+  text-align: center;
 }
 
-.sdz-form-col {
-  flex: 1;
-  min-width: 200px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+@keyframes sdz-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
 }
 
-.sdz-map {
-  height: 240px;
-  width: 100%;
-  border: 1px solid #e5e8ed;
-  border-radius: 8px;
-  margin-top: 8px;
+@media (max-width: 960px) {
+  .sdz-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .sdz-detail-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sdz-nav {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .sdz-hero-actions {
+    box-shadow: none;
+  }
 }


### PR DESCRIPTION
## 概要
- Web閲覧導線を整理（/favorites追加、関連スポット表示、マイページ導線）
- お気に入りをローカル保存し、ページング対応
- メール認証フローを統一し、既存メールはログイン誘導
- Google SSO時はパスワード再設定を案内のみ表示
- UIテスト追加とlocalStorageモック整備

## 変更点
- トップ/詳細/マイ/お気に入りページのUI調整
- 認証フォームの統一とエラーメッセージ改善
- UIテスト追加（favorites導線など）

Refs #136 #137 #138 #139 #140 #141 #148