### PR TITLE
Cloud Buildログ書き込み権限付与

### DIFF
--- a/resources/environments/dev/main.tf
+++ b/resources/environments/dev/main.tf
@@ -227,6 +227,12 @@ resource "google_project_iam_member" "sdz_deploy_service_usage_consumer" {
   member  = "serviceAccount:${google_service_account.sdz_dev_deploy_sa.email}"
 }
 
+resource "google_project_iam_member" "sdz_deploy_log_writer" {
+  project = var.sdz_project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.sdz_dev_deploy_sa.email}"
+}
+
 resource "google_storage_bucket_iam_member" "sdz_cloudbuild_sa_source_admin" {
   bucket = var.sdz_cloudbuild_source_bucket
   role   = "roles/storage.objectAdmin"


### PR DESCRIPTION
- 対応概要: Cloud Build実行SA(sdz-dev-deploy-sa)にroles/logging.logWriterを付与してCloud Loggingへの書き込み不足を解消\n  - Terraform: resources/environments/dev/main.tf にログ書き込み権限のIAMバインドを追加\n- 確認: terraform apply -var-file=environments/dev/terraform.tfvars 済み\n- 備考: Cloud BuildジョブはAPI/UIとも成功を確認（run 20718650842）