### PR TITLE
fix: セキュリティ脆弱性一括修正（CVE対応 + URL検証 + CI強化）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,12 @@ jobs:
         
       - name: 🧪 Run unit tests
         run: cargo test --verbose
-        
+
+      - name: 🛡️ Audit Rust dependencies
+        run: |
+          cargo install cargo-audit --locked || true
+          cargo audit
+
       - name: 🏗️ Build release binary
         run: cargo build --release --verbose
 
@@ -98,7 +103,11 @@ jobs:
       - name: 🧪 Run unit tests
         if: steps.lockfile.outputs.exists == 'yes'
         run: npm test -- --coverage --watch=false
-        
+
+      - name: 🛡️ Audit npm dependencies
+        if: steps.lockfile.outputs.exists == 'yes'
+        run: npm audit --audit-level=high
+
       - name: 🏗️ Build production bundle
         if: steps.lockfile.outputs.exists == 'yes'
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,14 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
-        
+
       - name: 🦀 Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-          
+
       - name: 📦 Cache Cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -79,7 +79,7 @@ jobs:
         if: steps.lockfile.outputs.exists == 'yes'
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/ui/package-lock.json
           
@@ -105,7 +105,7 @@ jobs:
         
       - name: 📊 Upload coverage reports
         if: steps.lockfile.outputs.exists == 'yes'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           directory: ./web/ui/coverage
 
@@ -132,10 +132,12 @@ jobs:
       - name: 🔍 Validate configuration
         run: terraform init -backend=false && terraform validate
         
-      - name: 🛡️ Security scan
-        uses: aquasecurity/tfsec-action@v1.0.3
+      - name: 🛡️ Security scan (Trivy)
+        uses: aquasecurity/trivy-action@0.35.0
         with:
-          working_directory: web/resources
+          scan-type: 'config'
+          scan-ref: 'web/resources'
+          format: 'table'
 
   # Docker イメージビルド
   docker-ci:
@@ -150,7 +152,7 @@ jobs:
         
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        
+
       - name: 🔐 Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -189,13 +191,13 @@ jobs:
         uses: actions/checkout@v4
         
       - name: 🔍 Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
           format: 'sarif'
           output: 'trivy-results.sarif'
-          
+
       - name: 📊 Upload Trivy scan results
         uses: github/codeql-action/upload-sarif@v3
         if: always()
@@ -213,7 +215,7 @@ jobs:
         uses: actions/checkout@v4
         
       - name: 🔍 Dependency Review
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
 

--- a/web/api/Cargo.lock
+++ b/web/api/Cargo.lock
@@ -158,9 +158,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -890,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -1257,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1611,30 +1611,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/web/api/Dockerfile
+++ b/web/api/Dockerfile
@@ -12,6 +12,7 @@ RUN cargo build --release
 FROM debian:bullseye-slim
 
 RUN apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends ca-certificates libssl1.1 \
   && rm -rf /var/lib/apt/lists/*
 

--- a/web/api/src/application/use_cases/update_spot_use_case.rs
+++ b/web/api/src/application/use_cases/update_spot_use_case.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use crate::{
     application::use_cases::spot_repository::SdzSpotRepository,
-    domain::models::{sdz_validate_urls, SdzSpot, SdzSpotLocation, SdzSpotType, SdzSpotValidationError},
+    domain::models::{
+        sdz_validate_spot, sdz_validate_urls, SdzSpot, SdzSpotLocation, SdzSpotType,
+        SdzSpotValidationError,
+    },
     presentation::error::SdzApiError,
 };
 
@@ -95,6 +98,13 @@ fn merge_spot(
     if let Some(sections) = input.sections {
         spot.sdz_sections = sections;
     }
+
+    sdz_validate_spot(
+        &spot.name,
+        spot.location.as_ref(),
+        &spot.tags,
+        &spot.images,
+    )?;
 
     let offset = chrono::FixedOffset::east_opt(9 * 3600).expect("valid offset");
     spot.updated_at = chrono::Utc::now().with_timezone(&offset);

--- a/web/api/src/application/use_cases/update_spot_use_case.rs
+++ b/web/api/src/application/use_cases/update_spot_use_case.rs
@@ -1,0 +1,187 @@
+use std::sync::Arc;
+
+use crate::{
+    application::use_cases::spot_repository::SdzSpotRepository,
+    domain::models::{sdz_validate_urls, SdzSpot, SdzSpotLocation, SdzSpotType, SdzSpotValidationError},
+    presentation::error::SdzApiError,
+};
+
+pub struct SdzUpdateSpotUseCase;
+
+impl SdzUpdateSpotUseCase {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn execute(
+        &self,
+        repo: Arc<dyn SdzSpotRepository>,
+        spot_id: String,
+        input: UpdateSpotInput,
+    ) -> Result<SdzSpot, SdzApiError> {
+        let existing = repo
+            .find_by_id(&spot_id)
+            .await?
+            .ok_or(SdzApiError::NotFound)?;
+
+        let updated = merge_spot(existing, input).map_err(map_validation_error)?;
+        repo.update(updated.clone()).await?;
+        Ok(updated)
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct UpdateSpotInput {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub location: Option<UpdateSpotLocation>,
+    pub tags: Option<Vec<String>>,
+    pub images: Option<Vec<String>>,
+    #[serde(rename = "spotType")]
+    pub spot_type: Option<String>,
+    #[serde(rename = "instagramUrl")]
+    pub instagram_url: Option<String>,
+    #[serde(rename = "officialUrl")]
+    pub official_url: Option<String>,
+    #[serde(rename = "businessHours")]
+    pub business_hours: Option<String>,
+    pub sections: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct UpdateSpotLocation {
+    pub lat: f64,
+    pub lng: f64,
+}
+
+fn merge_spot(
+    mut spot: SdzSpot,
+    input: UpdateSpotInput,
+) -> Result<SdzSpot, SdzSpotValidationError> {
+    if let Some(name) = input.name {
+        spot.name = name;
+    }
+    if let Some(desc) = input.description {
+        spot.description = Some(desc);
+    }
+    if let Some(loc) = input.location {
+        spot.location = Some(SdzSpotLocation {
+            lat: loc.lat,
+            lng: loc.lng,
+        });
+    }
+    if let Some(tags) = input.tags {
+        spot.tags = tags;
+    }
+    if let Some(images) = input.images {
+        spot.images = images;
+    }
+    if let Some(spot_type) = input.spot_type {
+        spot.sdz_spot_type = parse_spot_type_input(&spot_type);
+    }
+    if let Some(url) = input.instagram_url {
+        spot.sdz_instagram_url = if url.is_empty() { None } else { Some(url) };
+    }
+    if let Some(url) = input.official_url {
+        spot.sdz_official_url = if url.is_empty() { None } else { Some(url) };
+    }
+    sdz_validate_urls(
+        spot.sdz_instagram_url.as_deref(),
+        spot.sdz_official_url.as_deref(),
+    )?;
+    if let Some(hours) = input.business_hours {
+        spot.sdz_business_hours = if hours.is_empty() { None } else { Some(hours) };
+    }
+    if let Some(sections) = input.sections {
+        spot.sdz_sections = sections;
+    }
+
+    let offset = chrono::FixedOffset::east_opt(9 * 3600).expect("valid offset");
+    spot.updated_at = chrono::Utc::now().with_timezone(&offset);
+
+    Ok(spot)
+}
+
+fn parse_spot_type_input(value: &str) -> Option<SdzSpotType> {
+    match value {
+        "park" => Some(SdzSpotType::Park),
+        "street" => Some(SdzSpotType::Street),
+        _ => None,
+    }
+}
+
+fn map_validation_error(err: SdzSpotValidationError) -> SdzApiError {
+    SdzApiError::BadRequest(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::in_memory_spot_repository::SdzInMemorySpotRepository;
+
+    async fn seed_spot(repo: &Arc<dyn SdzSpotRepository>) -> SdzSpot {
+        let spot = SdzSpot::new_with_id(
+            "spot-1".into(),
+            "test park".into(),
+            Some("desc".into()),
+            None,
+            vec!["park".into()],
+            vec![],
+            "user-1".into(),
+        )
+        .unwrap();
+        repo.create(spot).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn update_spot_name() {
+        let repo: Arc<dyn SdzSpotRepository> = Arc::new(SdzInMemorySpotRepository::default());
+        seed_spot(&repo).await;
+
+        let use_case = SdzUpdateSpotUseCase::new();
+        let input = UpdateSpotInput {
+            name: Some("updated name".into()),
+            description: None,
+            location: None,
+            tags: None,
+            images: None,
+            spot_type: None,
+            instagram_url: None,
+            official_url: None,
+            business_hours: None,
+            sections: None,
+        };
+
+        let result = use_case
+            .execute(repo.clone(), "spot-1".into(), input)
+            .await
+            .unwrap();
+        assert_eq!(result.name, "updated name");
+        assert_eq!(result.description, Some("desc".into()));
+    }
+
+    #[tokio::test]
+    async fn update_spot_not_found() {
+        let repo: Arc<dyn SdzSpotRepository> = Arc::new(SdzInMemorySpotRepository::default());
+
+        let use_case = SdzUpdateSpotUseCase::new();
+        let input = UpdateSpotInput {
+            name: Some("name".into()),
+            description: None,
+            location: None,
+            tags: None,
+            images: None,
+            spot_type: None,
+            instagram_url: None,
+            official_url: None,
+            business_hours: None,
+            sections: None,
+        };
+
+        let err = use_case
+            .execute(repo, "nonexistent".into(), input)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SdzApiError::NotFound));
+    }
+}

--- a/web/api/src/domain/models.rs
+++ b/web/api/src/domain/models.rs
@@ -47,6 +47,16 @@ pub struct SdzSpot {
     pub sdz_trust_level: SdzSpotTrustLevel,
     #[serde(rename = "trustSources")]
     pub sdz_trust_sources: Vec<String>,
+    #[serde(rename = "spotType", skip_serializing_if = "Option::is_none")]
+    pub sdz_spot_type: Option<SdzSpotType>,
+    #[serde(rename = "instagramUrl", skip_serializing_if = "Option::is_none")]
+    pub sdz_instagram_url: Option<String>,
+    #[serde(rename = "officialUrl", skip_serializing_if = "Option::is_none")]
+    pub sdz_official_url: Option<String>,
+    #[serde(rename = "businessHours", skip_serializing_if = "Option::is_none")]
+    pub sdz_business_hours: Option<String>,
+    #[serde(rename = "sections", default)]
+    pub sdz_sections: Vec<String>,
     #[serde(rename = "userId")]
     pub sdz_user_id: String,
     #[serde(rename = "createdAt")]
@@ -60,6 +70,13 @@ pub struct SdzSpot {
 pub enum SdzSpotTrustLevel {
     Verified,
     Unverified,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SdzSpotType {
+    Park,
+    Street,
 }
 
 impl SdzSpot {
@@ -82,6 +99,48 @@ impl SdzSpot {
             images,
             sdz_trust_level: SdzSpotTrustLevel::Unverified,
             sdz_trust_sources: Vec::new(),
+            sdz_spot_type: None,
+            sdz_instagram_url: None,
+            sdz_official_url: None,
+            sdz_business_hours: None,
+            sdz_sections: Vec::new(),
+            sdz_user_id,
+            created_at: now_jst(),
+            updated_at: now_jst(),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_admin(
+        sdz_spot_id: String,
+        name: String,
+        description: Option<String>,
+        location: Option<SdzSpotLocation>,
+        tags: Vec<String>,
+        images: Vec<String>,
+        sdz_user_id: String,
+        sdz_spot_type: Option<SdzSpotType>,
+        sdz_instagram_url: Option<String>,
+        sdz_official_url: Option<String>,
+        sdz_business_hours: Option<String>,
+        sdz_sections: Vec<String>,
+    ) -> Result<Self, SdzSpotValidationError> {
+        validate_spot(&name, location.as_ref(), &tags, &images)?;
+        sdz_validate_urls(sdz_instagram_url.as_deref(), sdz_official_url.as_deref())?;
+        Ok(Self {
+            sdz_spot_id,
+            name,
+            description,
+            location,
+            tags,
+            images,
+            sdz_trust_level: SdzSpotTrustLevel::Verified,
+            sdz_trust_sources: vec!["admin".to_string()],
+            sdz_spot_type,
+            sdz_instagram_url,
+            sdz_official_url,
+            sdz_business_hours,
+            sdz_sections,
             sdz_user_id,
             created_at: now_jst(),
             updated_at: now_jst(),
@@ -115,6 +174,27 @@ fn validate_spot(
     Ok(())
 }
 
+pub fn sdz_validate_urls(
+    instagram_url: Option<&str>,
+    official_url: Option<&str>,
+) -> Result<(), SdzSpotValidationError> {
+    if let Some(url) = instagram_url {
+        if !url.is_empty() && !url.starts_with("https://") {
+            return Err(SdzSpotValidationError::InvalidUrl(
+                "instagramUrl must start with https://".into(),
+            ));
+        }
+    }
+    if let Some(url) = official_url {
+        if !url.is_empty() && !url.starts_with("https://") && !url.starts_with("http://") {
+            return Err(SdzSpotValidationError::InvalidUrl(
+                "officialUrl must start with http:// or https://".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn now_jst() -> DateTime<FixedOffset> {
     // 日本標準時（UTC+9）でタイムスタンプを付与
     let offset = FixedOffset::east_opt(9 * 3600).expect("valid offset");
@@ -133,4 +213,6 @@ pub enum SdzSpotValidationError {
     TooManyTags,
     #[error("images must be <= 10 items")]
     TooManyImages,
+    #[error("invalid url: {0}")]
+    InvalidUrl(String),
 }

--- a/web/api/src/domain/models.rs
+++ b/web/api/src/domain/models.rs
@@ -89,7 +89,7 @@ impl SdzSpot {
         images: Vec<String>,
         sdz_user_id: String,
     ) -> Result<Self, SdzSpotValidationError> {
-        validate_spot(&name, location.as_ref(), &tags, &images)?;
+        sdz_validate_spot(&name, location.as_ref(), &tags, &images)?;
         Ok(Self {
             sdz_spot_id,
             name,
@@ -125,7 +125,7 @@ impl SdzSpot {
         sdz_business_hours: Option<String>,
         sdz_sections: Vec<String>,
     ) -> Result<Self, SdzSpotValidationError> {
-        validate_spot(&name, location.as_ref(), &tags, &images)?;
+        sdz_validate_spot(&name, location.as_ref(), &tags, &images)?;
         sdz_validate_urls(sdz_instagram_url.as_deref(), sdz_official_url.as_deref())?;
         Ok(Self {
             sdz_spot_id,
@@ -148,7 +148,7 @@ impl SdzSpot {
     }
 }
 
-fn validate_spot(
+pub fn sdz_validate_spot(
     name: &str,
     location: Option<&SdzSpotLocation>,
     tags: &[String],
@@ -179,9 +179,9 @@ pub fn sdz_validate_urls(
     official_url: Option<&str>,
 ) -> Result<(), SdzSpotValidationError> {
     if let Some(url) = instagram_url {
-        if !url.is_empty() && !url.starts_with("https://") {
+        if !url.is_empty() && !url.starts_with("https://") && !url.starts_with("http://") {
             return Err(SdzSpotValidationError::InvalidUrl(
-                "instagramUrl must start with https://".into(),
+                "instagramUrl must start with http:// or https://".into(),
             ));
         }
     }

--- a/web/api/src/presentation/middleware/auth.rs
+++ b/web/api/src/presentation/middleware/auth.rs
@@ -125,6 +125,7 @@ async fn verify_firebase_token(token: &str) -> Result<FirebaseClaims, SdzApiErro
     let issuer = format!("https://securetoken.google.com/{}", project_id);
 
     let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_required_spec_claims(&["exp", "iss", "aud"]);
     validation.set_issuer(&[issuer]);
     validation.set_audience(&[project_id]);
     validation.validate_exp = true;

--- a/web/ui/package-lock.json
+++ b/web/ui/package-lock.json
@@ -94,6 +94,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -473,6 +474,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -496,6 +498,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -996,9 +999,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1092,6 +1095,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.2.tgz",
       "integrity": "sha512-jwtMmJa1BXXDCiDx1vC6SFN/+HfYG53UkfJa6qeN5ogvOunzbFDO3wISZy5n9xgYFUrEP6M7e8EG++riHNTv9w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.18",
         "@firebase/logger": "0.4.4",
@@ -1158,6 +1162,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.2.tgz",
       "integrity": "sha512-LssbyKHlwLeiV8GBATyOyjmHcMpX/tFjzRUCS1jnwGAew1VsBB4fJowyS5Ud5LdFbYpJeS+IQoC+RQxpK7eH3Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.13.2",
         "@firebase/component": "0.6.18",
@@ -1173,7 +1178,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth-compat": {
       "version": "0.5.28",
@@ -1624,6 +1630,7 @@
       "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1685,9 +1692,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1910,9 +1917,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
-      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -1924,9 +1931,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
-      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -1938,9 +1945,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
-      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -1952,9 +1959,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
-      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -1966,9 +1973,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
-      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -1980,9 +1987,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
-      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -1994,9 +2001,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
-      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
@@ -2008,9 +2015,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
-      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
@@ -2022,9 +2029,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
-      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
@@ -2036,9 +2043,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
-      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
@@ -2050,9 +2057,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
-      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
       ],
@@ -2064,9 +2085,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
-      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
@@ -2078,9 +2113,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
-      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
@@ -2092,9 +2127,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
-      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
@@ -2106,9 +2141,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
-      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
@@ -2120,9 +2155,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
@@ -2134,9 +2169,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
-      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
@@ -2147,10 +2182,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
-      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
       "cpu": [
         "arm64"
       ],
@@ -2162,9 +2211,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
-      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -2176,9 +2225,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
-      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -2190,9 +2239,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -2204,9 +2253,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
-      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -2451,6 +2500,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2506,6 +2556,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2836,6 +2887,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2864,9 +2916,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3018,9 +3070,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3060,6 +3112,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3648,6 +3701,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3752,9 +3806,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4051,9 +4105,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4226,9 +4280,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4931,6 +4985,7 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5027,7 +5082,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -5491,9 +5547,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5660,6 +5716,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5672,6 +5729,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5833,9 +5891,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
-      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5849,28 +5907,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.54.0",
-        "@rollup/rollup-android-arm64": "4.54.0",
-        "@rollup/rollup-darwin-arm64": "4.54.0",
-        "@rollup/rollup-darwin-x64": "4.54.0",
-        "@rollup/rollup-freebsd-arm64": "4.54.0",
-        "@rollup/rollup-freebsd-x64": "4.54.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
-        "@rollup/rollup-linux-arm64-musl": "4.54.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-musl": "4.54.0",
-        "@rollup/rollup-openharmony-arm64": "4.54.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
-        "@rollup/rollup-win32-x64-gnu": "4.54.0",
-        "@rollup/rollup-win32-x64-msvc": "4.54.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -6305,11 +6366,12 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6420,6 +6482,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6502,6 +6565,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6590,11 +6654,12 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6608,6 +6673,7 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",
@@ -6681,9 +6747,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/ui/src/admin/SdzAdminSpotForm.tsx
+++ b/web/ui/src/admin/SdzAdminSpotForm.tsx
@@ -1,0 +1,384 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useAuth } from '../contexts/useAuth';
+import type { SdzSpot } from '../types/spot';
+import {
+  sdzAdminCreateSpot,
+  sdzAdminUpdateSpot,
+  sdzAdminGetUploadUrl,
+  sdzAdminUploadImage,
+} from '../lib/SdzAdminApi';
+
+const sdzApiUrl = import.meta.env.VITE_SDZ_API_URL || 'http://localhost:8080';
+
+const SDZ_ALLOWED_URL_SCHEMES = ['https:', 'http:'];
+
+function sdzValidateUrl(value: string): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (!SDZ_ALLOWED_URL_SCHEMES.includes(url.protocol)) {
+      return `許可されていないURLスキームです: ${url.protocol}`;
+    }
+    return null;
+  } catch {
+    return '無効なURL形式です';
+  }
+}
+
+export function SdzAdminSpotForm() {
+  const { id } = useParams();
+  const isEdit = id != null;
+  const navigate = useNavigate();
+  const { idToken } = useAuth();
+
+  const [sdzName, setSdzName] = useState('');
+  const [sdzDescription, setSdzDescription] = useState('');
+  const [sdzLat, setSdzLat] = useState('');
+  const [sdzLng, setSdzLng] = useState('');
+  const [sdzSpotType, setSdzSpotType] = useState('park');
+  const [sdzInstagramUrl, setSdzInstagramUrl] = useState('');
+  const [sdzOfficialUrl, setSdzOfficialUrl] = useState('');
+  const [sdzBusinessHours, setSdzBusinessHours] = useState('');
+  const [sdzSections, setSdzSections] = useState('');
+  const [sdzTags, setSdzTags] = useState('');
+  const [sdzImages, setSdzImages] = useState<string[]>([]);
+  const [sdzUploading, setSdzUploading] = useState(false);
+  const [sdzSubmitting, setSdzSubmitting] = useState(false);
+  const [sdzError, setSdzError] = useState<string | null>(null);
+  const [sdzSuccess, setSdzSuccess] = useState<string | null>(null);
+  const [sdzLoadingSpot, setSdzLoadingSpot] = useState(false);
+
+  useEffect(() => {
+    if (!isEdit) return;
+    setSdzLoadingSpot(true);
+    fetch(`${sdzApiUrl}/sdz/spots/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<SdzSpot>;
+      })
+      .then((spot) => {
+        setSdzName(spot.name);
+        setSdzDescription(spot.description ?? '');
+        setSdzLat(spot.location?.lat?.toString() ?? '');
+        setSdzLng(spot.location?.lng?.toString() ?? '');
+        setSdzSpotType(spot.spotType ?? 'park');
+        setSdzInstagramUrl(spot.instagramUrl ?? '');
+        setSdzOfficialUrl(spot.officialUrl ?? '');
+        setSdzBusinessHours(spot.businessHours ?? '');
+        setSdzSections(spot.sections?.join(', ') ?? '');
+        setSdzTags(spot.tags?.join(', ') ?? '');
+        setSdzImages(spot.images ?? []);
+      })
+      .catch((err) => setSdzError((err as Error).message))
+      .finally(() => setSdzLoadingSpot(false));
+  }, [id, isEdit]);
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || !idToken) return;
+
+    setSdzUploading(true);
+    setSdzError(null);
+    try {
+      for (const file of Array.from(files)) {
+        if (sdzImages.length >= 10) break;
+        const result = await sdzAdminGetUploadUrl(idToken, file.type);
+        await sdzAdminUploadImage(result.uploadUrl, file);
+        setSdzImages((prev) => [...prev, result.objectUrl]);
+      }
+    } catch (err) {
+      setSdzError((err as Error).message);
+    } finally {
+      setSdzUploading(false);
+      e.target.value = '';
+    }
+  };
+
+  const handleRemoveImage = (index: number) => {
+    setSdzImages((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!idToken) {
+      setSdzError('認証トークンがありません');
+      return;
+    }
+
+    setSdzSubmitting(true);
+    setSdzError(null);
+    setSdzSuccess(null);
+
+    const sdzInstagramUrlError = sdzValidateUrl(sdzInstagramUrl);
+    if (sdzInstagramUrlError) {
+      setSdzError(`Instagram URL: ${sdzInstagramUrlError}`);
+      setSdzSubmitting(false);
+      return;
+    }
+    const sdzOfficialUrlError = sdzValidateUrl(sdzOfficialUrl);
+    if (sdzOfficialUrlError) {
+      setSdzError(`公式サイトURL: ${sdzOfficialUrlError}`);
+      setSdzSubmitting(false);
+      return;
+    }
+
+    const parseSplit = (value: string) =>
+      value
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+    const location =
+      sdzLat && sdzLng
+        ? { lat: parseFloat(sdzLat), lng: parseFloat(sdzLng) }
+        : undefined;
+
+    try {
+      if (isEdit) {
+        await sdzAdminUpdateSpot(idToken, id, {
+          name: sdzName,
+          description: sdzDescription || undefined,
+          location,
+          tags: parseSplit(sdzTags),
+          images: sdzImages,
+          spotType: sdzSpotType,
+          instagramUrl: sdzInstagramUrl || undefined,
+          officialUrl: sdzOfficialUrl || undefined,
+          businessHours: sdzBusinessHours || undefined,
+          sections: parseSplit(sdzSections),
+        });
+        setSdzSuccess('スポットを更新しました');
+      } else {
+        await sdzAdminCreateSpot(idToken, {
+          name: sdzName,
+          description: sdzDescription || undefined,
+          location,
+          tags: parseSplit(sdzTags),
+          images: sdzImages,
+          spotType: sdzSpotType,
+          instagramUrl: sdzInstagramUrl || undefined,
+          officialUrl: sdzOfficialUrl || undefined,
+          businessHours: sdzBusinessHours || undefined,
+          sections: parseSplit(sdzSections),
+        });
+        setSdzSuccess('スポットを作成しました');
+        setTimeout(() => navigate('/admin'), 1000);
+      }
+    } catch (err) {
+      setSdzError((err as Error).message);
+    } finally {
+      setSdzSubmitting(false);
+    }
+  };
+
+  if (sdzLoadingSpot) {
+    return <p>スポット情報を読み込み中...</p>;
+  }
+
+  return (
+    <div className="sdz-card">
+      <h3>{isEdit ? 'スポット編集' : 'スポット新規作成'}</h3>
+
+      {sdzError && <div className="sdz-error" style={{ marginBottom: 12 }}>{sdzError}</div>}
+      {sdzSuccess && <div style={{ color: '#4caf50', marginBottom: 12 }}>{sdzSuccess}</div>}
+
+      <form onSubmit={handleSubmit}>
+        <div style={{ display: 'grid', gap: 12 }}>
+          <div>
+            <label htmlFor="sdz-name">スポット名 *</label>
+            <input
+              id="sdz-name"
+              type="text"
+              value={sdzName}
+              onChange={(e) => setSdzName(e.target.value)}
+              required
+              style={{ width: '100%' }}
+            />
+          </div>
+
+          <div>
+            <label>スポットタイプ</label>
+            <div style={{ display: 'flex', gap: 16 }}>
+              <label>
+                <input
+                  type="radio"
+                  name="spotType"
+                  value="park"
+                  checked={sdzSpotType === 'park'}
+                  onChange={(e) => setSdzSpotType(e.target.value)}
+                />{' '}
+                パーク
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="spotType"
+                  value="street"
+                  checked={sdzSpotType === 'street'}
+                  onChange={(e) => setSdzSpotType(e.target.value)}
+                />{' '}
+                ストリート
+              </label>
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="sdz-description">説明</label>
+            <textarea
+              id="sdz-description"
+              value={sdzDescription}
+              onChange={(e) => setSdzDescription(e.target.value)}
+              rows={3}
+              style={{ width: '100%' }}
+            />
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+            <div>
+              <label htmlFor="sdz-lat">緯度</label>
+              <input
+                id="sdz-lat"
+                type="number"
+                step="any"
+                value={sdzLat}
+                onChange={(e) => setSdzLat(e.target.value)}
+                placeholder="35.6812"
+                style={{ width: '100%' }}
+              />
+            </div>
+            <div>
+              <label htmlFor="sdz-lng">経度</label>
+              <input
+                id="sdz-lng"
+                type="number"
+                step="any"
+                value={sdzLng}
+                onChange={(e) => setSdzLng(e.target.value)}
+                placeholder="139.7671"
+                style={{ width: '100%' }}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="sdz-instagram-url">Instagram 位置情報ページURL</label>
+            <input
+              id="sdz-instagram-url"
+              type="url"
+              value={sdzInstagramUrl}
+              onChange={(e) => setSdzInstagramUrl(e.target.value)}
+              placeholder="https://www.instagram.com/explore/locations/..."
+              style={{ width: '100%' }}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="sdz-official-url">公式サイトURL</label>
+            <input
+              id="sdz-official-url"
+              type="url"
+              value={sdzOfficialUrl}
+              onChange={(e) => setSdzOfficialUrl(e.target.value)}
+              placeholder="https://..."
+              style={{ width: '100%' }}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="sdz-business-hours">営業時間</label>
+            <input
+              id="sdz-business-hours"
+              type="text"
+              value={sdzBusinessHours}
+              onChange={(e) => setSdzBusinessHours(e.target.value)}
+              placeholder="平日 9:00-21:00 / 土日 8:00-22:00"
+              style={{ width: '100%' }}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="sdz-sections">セクション（カンマ区切り）</label>
+            <input
+              id="sdz-sections"
+              type="text"
+              value={sdzSections}
+              onChange={(e) => setSdzSections(e.target.value)}
+              placeholder="ミニランプ, フラットレール, ボウル"
+              style={{ width: '100%' }}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="sdz-tags">タグ（カンマ区切り）</label>
+            <input
+              id="sdz-tags"
+              type="text"
+              value={sdzTags}
+              onChange={(e) => setSdzTags(e.target.value)}
+              placeholder="初心者OK, 照明あり, 駐車場あり"
+              style={{ width: '100%' }}
+            />
+          </div>
+
+          <div>
+            <label>画像 ({sdzImages.length}/10)</label>
+            {sdzImages.length > 0 && (
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 8 }}>
+                {sdzImages.map((url, i) => (
+                  <div key={url} style={{ position: 'relative' }}>
+                    <img
+                      src={url}
+                      alt={`画像${i + 1}`}
+                      style={{ width: 120, height: 80, objectFit: 'cover', borderRadius: 4 }}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveImage(i)}
+                      style={{
+                        position: 'absolute',
+                        top: -4,
+                        right: -4,
+                        background: '#e53935',
+                        color: '#fff',
+                        border: 'none',
+                        borderRadius: '50%',
+                        width: 20,
+                        height: 20,
+                        cursor: 'pointer',
+                        fontSize: 12,
+                        lineHeight: '20px',
+                        padding: 0,
+                      }}
+                    >
+                      x
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            {sdzImages.length < 10 && (
+              <input
+                type="file"
+                accept="image/jpeg,image/png,image/webp,image/heic,image/heif"
+                multiple
+                onChange={handleImageUpload}
+                disabled={sdzUploading}
+              />
+            )}
+            {sdzUploading && <p className="sdz-meta">アップロード中...</p>}
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+            <button type="submit" disabled={sdzSubmitting || !sdzName}>
+              {sdzSubmitting ? '保存中...' : isEdit ? '更新' : '作成'}
+            </button>
+            <button type="button" className="sdz-ghost" onClick={() => navigate('/admin')}>
+              キャンセル
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/ui/src/admin/SdzAdminSpotForm.tsx
+++ b/web/ui/src/admin/SdzAdminSpotForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '../contexts/useAuth';
 import type { SdzSpot } from '../types/spot';
@@ -8,6 +8,7 @@ import {
   sdzAdminGetUploadUrl,
   sdzAdminUploadImage,
 } from '../lib/SdzAdminApi';
+import { SdzAdminMapPicker } from './SdzAdminMapPicker';
 
 const sdzApiUrl = import.meta.env.VITE_SDZ_API_URL || 'http://localhost:8080';
 
@@ -44,6 +45,11 @@ export function SdzAdminSpotForm() {
   const [sdzTags, setSdzTags] = useState('');
   const [sdzImages, setSdzImages] = useState<string[]>([]);
   const [sdzUploading, setSdzUploading] = useState(false);
+
+  const handleLocationChange = useCallback((lat: string, lng: string) => {
+    setSdzLat(lat);
+    setSdzLng(lng);
+  }, []);
   const [sdzSubmitting, setSdzSubmitting] = useState(false);
   const [sdzError, setSdzError] = useState<string | null>(null);
   const [sdzSuccess, setSdzSuccess] = useState<string | null>(null);
@@ -129,9 +135,11 @@ export function SdzAdminSpotForm() {
         .map((s) => s.trim())
         .filter(Boolean);
 
+    const parsedLat = parseFloat(sdzLat);
+    const parsedLng = parseFloat(sdzLng);
     const location =
-      sdzLat && sdzLng
-        ? { lat: parseFloat(sdzLat), lng: parseFloat(sdzLng) }
+      sdzLat && sdzLng && Number.isFinite(parsedLat) && Number.isFinite(parsedLng)
+        ? { lat: parsedLat, lng: parsedLng }
         : undefined;
 
     try {
@@ -234,30 +242,38 @@ export function SdzAdminSpotForm() {
             />
           </div>
 
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
-            <div>
-              <label htmlFor="sdz-lat">緯度</label>
-              <input
-                id="sdz-lat"
-                type="number"
-                step="any"
-                value={sdzLat}
-                onChange={(e) => setSdzLat(e.target.value)}
-                placeholder="35.6812"
-                style={{ width: '100%' }}
-              />
-            </div>
-            <div>
-              <label htmlFor="sdz-lng">経度</label>
-              <input
-                id="sdz-lng"
-                type="number"
-                step="any"
-                value={sdzLng}
-                onChange={(e) => setSdzLng(e.target.value)}
-                placeholder="139.7671"
-                style={{ width: '100%' }}
-              />
+          <div>
+            <label>位置情報</label>
+            <SdzAdminMapPicker
+              lat={sdzLat}
+              lng={sdzLng}
+              onLocationChange={handleLocationChange}
+            />
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginTop: 8 }}>
+              <div>
+                <label htmlFor="sdz-lat">緯度</label>
+                <input
+                  id="sdz-lat"
+                  type="number"
+                  step="any"
+                  value={sdzLat}
+                  onChange={(e) => setSdzLat(e.target.value)}
+                  placeholder="35.6812"
+                  style={{ width: '100%' }}
+                />
+              </div>
+              <div>
+                <label htmlFor="sdz-lng">経度</label>
+                <input
+                  id="sdz-lng"
+                  type="number"
+                  step="any"
+                  value={sdzLng}
+                  onChange={(e) => setSdzLng(e.target.value)}
+                  placeholder="139.7671"
+                  style={{ width: '100%' }}
+                />
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

セキュリティスキャンで検出されたP0/P1脆弱性を一括修正するhotfixブランチ。

## Changes

- Rust依存クレートの脆弱性修正（bytes/quinn-proto/rustls-webpki/time）
- npm依存パッケージの脆弱性修正（rollup CVE-2026-27606 / minimatch ReDoS x13 等）
- GitHub Actions のバージョン固定・更新（trivy-action@master → @0.35.0 等）
- JWT検証の防御強化（required_spec_claims に exp/iss/aud を明示指定）
- Dockerfile に `apt-get upgrade` を追加（セキュリティパッチ適用）
- URL スキーム検証の強化（API update_spot + Web管理画面）

## Test plan

- [x] `cargo check` — コンパイル成功
- [x] `cargo test` — 10テスト全通過
- [ ] CI パイプラインの通過を確認
- [ ] ステージング環境でのスモークテスト

## Related issues

- closes #210
- closes #204
- closes #260
- closes #261
- closes #211
- closes #191
- closes #262
- closes #205
- closes #206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin UI to create/edit spots with expanded fields (spot type, social URLs, business hours, sections) and multi-image upload (up to 10 images).
  * Client-side URL validation with localized Japanese error messages.
  * Server-side spot update endpoint supporting partial updates and stricter URL validation.

* **Bug Fixes / Reliability**
  * Improved token validation behavior for authentication checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->