### PR TITLE
fix(web): SdzSpot 型に管理画面フィールドを追加

### DIFF
--- a/web/ui/src/types/spot.ts
+++ b/web/ui/src/types/spot.ts
@@ -3,6 +3,8 @@ export interface SdzSpotLocation {
   lng: number;
 }
 
+export type SdzSpotType = 'park' | 'street';
+
 export interface SdzSpot {
   spotId: string;
   name: string;
@@ -12,6 +14,11 @@ export interface SdzSpot {
   images: string[];
   trustLevel: 'verified' | 'unverified';
   trustSources?: string[];
+  spotType?: SdzSpotType;
+  instagramUrl?: string;
+  officialUrl?: string;
+  businessHours?: string;
+  sections?: string[];
   userId: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary

SdzAdminSpotForm が参照するフィールドが SdzSpot 型定義に不足しており CI の型チェックが失敗していた。

## Changes

- `SdzSpotType` 型エイリアスを追加
- `SdzSpot` に `spotType`, `instagramUrl`, `officialUrl`, `businessHours`, `sections` を追加

## Test plan

- [x] ローカル `tsc --noEmit` 通過
- [ ] CI 型チェック通過確認

## Related issues

N/A（CI修正）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spots now support additional information fields: type classification (park or street), Instagram and official URLs, business hours, and section details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->