### PR TITLE
feat(web): 管理画面ルーティング・コンポーネント追加

### DIFF
--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -4,6 +4,10 @@ import { useAuth } from './contexts/useAuth';
 import { Route, Routes, useNavigate, useParams } from 'react-router-dom';
 import { CircleMarker, MapContainer, TileLayer, Tooltip, useMap } from 'react-leaflet';
 import L from 'leaflet';
+import { SdzAdminGuard } from './admin/SdzAdminGuard';
+import { SdzAdminLayout } from './admin/SdzAdminLayout';
+import { SdzAdminSpotList } from './admin/SdzAdminSpotList';
+import { SdzAdminSpotForm } from './admin/SdzAdminSpotForm';
 
 const apiUrl = import.meta.env.VITE_SDZ_API_URL || 'http://localhost:8080';
 const SDZ_FAVORITES_PAGE_SIZE = 8;
@@ -1216,6 +1220,13 @@ function App() {
             </div>
           }
         />
+        <Route element={<SdzAdminGuard />}>
+          <Route element={<SdzAdminLayout />}>
+            <Route path="/admin" element={<SdzAdminSpotList />} />
+            <Route path="/admin/spots/new" element={<SdzAdminSpotForm />} />
+            <Route path="/admin/spots/:id/edit" element={<SdzAdminSpotForm />} />
+          </Route>
+        </Route>
       </Routes>
     </div>
   );

--- a/web/ui/src/admin/SdzAdminGuard.tsx
+++ b/web/ui/src/admin/SdzAdminGuard.tsx
@@ -1,0 +1,17 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../contexts/useAuth';
+
+// 管理画面アクセスガード: 認証済みユーザーのみ許可
+export function SdzAdminGuard() {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return <p>認証確認中...</p>;
+  }
+
+  if (!user) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/web/ui/src/admin/SdzAdminLayout.tsx
+++ b/web/ui/src/admin/SdzAdminLayout.tsx
@@ -1,0 +1,21 @@
+import { Link, Outlet } from 'react-router-dom';
+
+// 管理画面の共通レイアウト
+export function SdzAdminLayout() {
+  return (
+    <div style={{ maxWidth: 960, margin: '0 auto', padding: 16 }}>
+      <nav style={{ marginBottom: 16, display: 'flex', gap: 16, alignItems: 'center' }}>
+        <Link to="/admin" style={{ fontWeight: 600, textDecoration: 'none' }}>
+          管理画面
+        </Link>
+        <Link to="/admin/spots/new" style={{ textDecoration: 'none' }}>
+          + スポット作成
+        </Link>
+        <Link to="/" style={{ marginLeft: 'auto', textDecoration: 'none', fontSize: 14 }}>
+          ← サイトに戻る
+        </Link>
+      </nav>
+      <Outlet />
+    </div>
+  );
+}

--- a/web/ui/src/admin/SdzAdminSpotList.tsx
+++ b/web/ui/src/admin/SdzAdminSpotList.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { SdzSpot } from '../types/spot';
+
+const sdzApiUrl = import.meta.env.VITE_SDZ_API_URL || 'http://localhost:8080';
+
+// 管理画面: スポット一覧
+export function SdzAdminSpotList() {
+  const [sdzSpots, setSdzSpots] = useState<SdzSpot[]>([]);
+  const [sdzLoading, setSdzLoading] = useState(true);
+  const [sdzError, setSdzError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${sdzApiUrl}/sdz/spots`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<SdzSpot[]>;
+      })
+      .then(setSdzSpots)
+      .catch((err) => setSdzError((err as Error).message))
+      .finally(() => setSdzLoading(false));
+  }, []);
+
+  if (sdzLoading) return <p>読み込み中...</p>;
+  if (sdzError) return <div className="sdz-error">エラー: {sdzError}</div>;
+
+  return (
+    <div className="sdz-card">
+      <h2>スポット管理</h2>
+      <p className="sdz-meta">{sdzSpots.length}件のスポット</p>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 12 }}>
+        {sdzSpots.map((spot) => (
+          <Link
+            key={spot.spotId}
+            to={`/admin/spots/${spot.spotId}/edit`}
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              padding: '8px 12px',
+              border: '1px solid #e0e0e0',
+              borderRadius: 6,
+              textDecoration: 'none',
+              color: 'inherit',
+            }}
+          >
+            <div>
+              <div style={{ fontWeight: 500 }}>{spot.name}</div>
+              <div style={{ fontSize: 12, color: '#888' }}>
+                {spot.spotType ?? '未分類'} ・ {spot.tags.join(', ') || 'タグなし'}
+              </div>
+            </div>
+            <span style={{ fontSize: 12, color: '#999' }}>編集 →</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

管理画面にアクセスできない問題を修正。ルーティングと必要なコンポーネントを追加。

## Changes

- `SdzAdminGuard`: 認証ガード（未ログインは `/` にリダイレクト）
- `SdzAdminLayout`: 管理画面共通ナビゲーション
- `SdzAdminSpotList`: スポット一覧（各スポットの編集リンク付き）
- `App.tsx`: `/admin`, `/admin/spots/new`, `/admin/spots/:id/edit` ルートを追加

## Test plan

- [x] `tsc --noEmit` — 型チェック通過
- [x] `vitest run` — 3テスト全通過
- [ ] `http://localhost:3000/#/admin` でスポット一覧が表示される
- [ ] `http://localhost:3000/#/admin/spots/new` で作成フォームが表示される
- [ ] 未ログイン時はトップページにリダイレクトされる

## Related issues

N/A